### PR TITLE
Implement asynchronous suspend/resume methods for system module

### DIFF
--- a/include/public/nyx/client/nyx_system.h
+++ b/include/public/nyx/client/nyx_system.h
@@ -103,6 +103,30 @@ NYX_API_EXPORT nyx_error_t nyx_system_query_rtc_time(nyx_device_handle_t handle,
 NYX_API_EXPORT nyx_error_t nyx_system_suspend(nyx_device_handle_t handle,
         bool *success);
 
+/**
+ * @brief Suspend the device asynchronously.
+ *
+ * @param[in]  handle - the handle returned from nyx_device_open
+ * @param[out] success - true if device was able to suspend
+ *
+ * @return error code (NYX_ERROR_NONE if operation is successful)
+ *
+ */
+
+NYX_API_EXPORT nyx_error_t nyx_system_suspend_async(nyx_device_handle_t handle,
+        bool *success);
+
+/**
+ * @brief Resume the device after it was suspended asynchronously.
++ *
+ * @param[in] handle - the handle returned from nyx_device_open
+ * @param[out] success - true if device was able to resume
+ *
+ * @return error code (NYX_ERROR_NONE if operation is successful)
+ */
+
+NYX_API_EXPORT nyx_error_t nyx_system_resume(nyx_device_handle_t handle,
+        bool *success);
 
 /**
  * @brief Shut down the device.

--- a/include/public/nyx/client/nyx_system.h
+++ b/include/public/nyx/client/nyx_system.h
@@ -69,7 +69,6 @@ NYX_API_EXPORT nyx_error_t nyx_system_set_alarm(nyx_device_handle_t handle,
 NYX_API_EXPORT nyx_error_t nyx_system_query_next_alarm(nyx_device_handle_t
         handle, time_t *time);
 
-
 /**
  * @brief Query current RTC time.
  *
@@ -83,8 +82,6 @@ NYX_API_EXPORT nyx_error_t nyx_system_query_next_alarm(nyx_device_handle_t
 
 NYX_API_EXPORT nyx_error_t nyx_system_query_rtc_time(nyx_device_handle_t handle,
         time_t *time);
-
-
 
 /**
  * @brief Suspend the device.
@@ -141,7 +138,6 @@ NYX_API_EXPORT nyx_error_t nyx_system_resume(nyx_device_handle_t handle,
 
 NYX_API_EXPORT nyx_error_t nyx_system_shutdown(nyx_device_handle_t handle,
         nyx_system_shutdown_type_t type, const char *reason);
-
 
 /**
  * @brief boost up the device for pre-configured duration.

--- a/include/public/nyx/module/nyx_device_internal.h
+++ b/include/public/nyx/module/nyx_device_internal.h
@@ -92,6 +92,8 @@ typedef enum
 	NYX_SYSTEM_QUERY_NEXT_ALARM_MODULE_METHOD,
 	NYX_SYSTEM_QUERY_RTC_TIME_MODULE_METHOD,
 	NYX_SYSTEM_SUSPEND_MODULE_METHOD,
+	NYX_SYSTEM_SUSPEND_ASYNC_MODULE_METHOD,
+	NYX_SYSTEM_RESUME_MODULE_METHOD,
 	NYX_SYSTEM_SHUTDOWN_MODULE_METHOD,
 	NYX_SYSTEM_REBOOT_MODULE_METHOD,
 	NYX_SYSTEM_ERASE_PARTITION_MODULE_METHOD,
@@ -298,6 +300,8 @@ typedef nyx_error_t (*nyx_system_query_next_alarm_function_t)(nyx_device_t *,
 typedef nyx_error_t (*nyx_system_query_rtc_time_function_t)(nyx_device_t *,
         time_t *);
 typedef nyx_error_t (*nyx_system_suspend_function_t)(nyx_device_t *, bool *);
+typedef nyx_error_t (*nyx_system_suspend_async_function_t)(nyx_device_t *, bool *);
+typedef nyx_error_t (*nyx_system_resume_function_t)(nyx_device_t *, bool *);
 typedef nyx_error_t (*nyx_system_shutdown_function_t)(nyx_device_t *,
         nyx_system_shutdown_type_t, const char *);
 typedef nyx_error_t (*nyx_system_reboot_function_t)(nyx_device_t *,

--- a/src/device/nyx_system_impl.c
+++ b/src/device/nyx_system_impl.c
@@ -53,6 +53,16 @@ nyx_error_t nyx_system_suspend(nyx_device_handle_t handle, bool *success)
 	nyx_execute_return_function(system_suspend, SYSTEM, SUSPEND, handle, success);
 }
 
+nyx_error_t nyx_system_suspend_async(nyx_device_handle_t handle, bool *success)
+{
+	nyx_execute_return_function(system_suspend_async, SYSTEM, SUSPEND_ASYNC, handle, success);
+}
+
+nyx_error_t nyx_system_resume(nyx_device_handle_t handle, bool *success)
+{
+	nyx_execute_return_function(system_resume, SYSTEM, RESUME, handle, success);
+}
+
 nyx_error_t nyx_system_shutdown(nyx_device_handle_t handle,
                                 nyx_system_shutdown_type_t type, const char *reason)
 {


### PR DESCRIPTION
Especially in Android based systems suspend isn't synchronous. They are working with
wakelocks and therefor the request to suspend is only an intent and the device will not
suspend as long as no wakelock is hold anymore. The system needs to detect manually
when it should switch back to a alive state. With the new API the power management
implementation can request suspending the system with calling the new suspend_async
method and resuming through the resume method.

Open-webOS-DCO-1.0-Signed-off-by: Simon Busch <morphis@gravedo.de>
Signed-off-by: Herman van Hazendonk <github.com@herrie.org>